### PR TITLE
ログイン失敗時の手動入力URLがundefinedになってしまうバグを修正

### DIFF
--- a/__tests__/WorksClient.spec.ts
+++ b/__tests__/WorksClient.spec.ts
@@ -1,0 +1,15 @@
+import { WorksClient } from "../src/WorksClient";
+
+describe("WorksClient", () => {
+  describe("punchingURLForPc", () => {
+    it("success", () => {
+      const client = new WorksClient(
+        "proxy-domain.example.com",
+        "domain.example.com"
+      );
+      expect(client.punchingURLForPc).toEqual(
+        `https://domain.example.com/self-workflow/cws/srwtimerec?@DIRECT=true`
+      );
+    });
+  });
+});

--- a/src/WorksClient.ts
+++ b/src/WorksClient.ts
@@ -13,7 +13,7 @@ class WorksClientError extends BaseError {
 class WorksClient {
   public credential: UserCredential = null;
 
-  public constructor(private proxyDomain: string, domain: string) {}
+  public constructor(private proxyDomain: string, private domain: string) {}
 
   public get authenticated(): boolean {
     return this.credential !== null;


### PR DESCRIPTION
ログイン失敗時に表示される手動入力URL`worksClient.punchingURLForPc`について、
https://github.com/k2tzumi/hue-kintai-slask-command/blob/d9daf99e4b374a07d76a8356aff06971e8a043a6/src/Code.ts#L553-L562

中で使っている`domain`プロパティがundefinedになっているようでした。
https://github.com/k2tzumi/hue-kintai-slask-command/blob/d9daf99e4b374a07d76a8356aff06971e8a043a6/src/WorksClient.ts#L134-L136

WorksClientの初期化時、プロパティに同時にセットする場合は個別にアクセス修飾子を付ける必要がありそうです。
動作を確認するテストと修正を加えてみました。

- 動作を確認するテストを追加: 826c5cd
- アクセス修飾子の修正: 661a719